### PR TITLE
Split build workflow to avoid generating doc on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions,
-# run static analysis with Qodana, and deploy reports
+# This workflow will install Python dependencies, run tests and lint with a
+# variety of Python versions.
 
 name: Build
 
@@ -15,9 +15,6 @@ on:
 
 env:
   PYTHON_VERSION: '3.11'
-
-permissions:
-  contents: write
 
 jobs:
   build:
@@ -49,139 +46,3 @@ jobs:
         run: |
           poetry run python -m unittest discover -p 'test_*.py' -t ..
         working-directory: tests
-
-  qodana:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Run Qodana scan
-        uses: JetBrains/qodana-action@main
-        with:
-          upload-result: false
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
-
-#      - name: Set scanning alerts
-#        uses: github/codeql-action/upload-sarif@v2
-#        with:
-#          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifact-qodana
-          path: ${{ runner.temp }}/qodana/results/report/
-
-  sphinx:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up Poetry
-        run: pipx install poetry
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
-
-      - name: Install Python dependencies
-        run: |
-          poetry run python -m pip install -U pip
-          poetry install
-
-      - name: Generate docs
-        run: |
-          poetry run sphinx-apidoc -o docs .
-          poetry run sphinx-build -b html docs docs/_build
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifact-sphinx
-          path: docs/_build/
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up Poetry
-        run: pipx install poetry
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
-
-      - name: Install Python dependencies
-        run: |
-          poetry run python -m pip install -U pip
-          poetry install
-
-      - name: Run coverage
-        run: |
-          poetry run coverage run -m unittest discover
-          poetry run coverage html
-          rm htmlcov/.gitignore
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifact-coverage
-          path: htmlcov/
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [ qodana, sphinx, coverage ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifact (qodana)
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact-qodana
-          path: build/qodana
-
-      - name: Download artifact (sphinx)
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact-sphinx
-          path: build/docs
-
-      - name: Download artifact (coverage)
-        uses: actions/download-artifact@v3
-        with:
-          name: artifact-coverage
-          path: build/cov
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: build
-          destination_dir: ./
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-
-  cleanup:
-    runs-on: ubuntu-latest
-    if: always()
-    needs: deploy
-    steps:
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          failOnError: false
-          name: |
-            artifact-*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,147 @@
+# This workflow will install Python dependencies, run static analysis with
+# Qodana, generate docs, check coverage and deploy reports.
+
+name: Documentation
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches:
+      - main
+
+env:
+  PYTHON_VERSION: '3.11'
+
+permissions:
+  contents: write
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run Qodana scan
+        uses: JetBrains/qodana-action@main
+        with:
+          upload-result: false
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+
+#      - name: Set scanning alerts
+#        uses: github/codeql-action/upload-sarif@v2
+#        with:
+#          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact-qodana
+          path: ${{ runner.temp }}/qodana/results/report/
+
+  sphinx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'poetry'
+
+      - name: Install Python dependencies
+        run: |
+          poetry run python -m pip install -U pip
+          poetry install
+      - name: Generate docs
+        run: |
+          poetry run sphinx-apidoc -o docs .
+          poetry run sphinx-build -b html docs docs/_build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact-sphinx
+          path: docs/_build/
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'poetry'
+
+      - name: Install Python dependencies
+        run: |
+          poetry run python -m pip install -U pip
+          poetry install
+      - name: Run coverage
+        run: |
+          poetry run coverage run -m unittest discover
+          poetry run coverage html
+          rm htmlcov/.gitignore
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact-coverage
+          path: htmlcov/
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ qodana, sphinx, coverage ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download artifact (qodana)
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact-qodana
+          path: build/qodana
+
+      - name: Download artifact (sphinx)
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact-sphinx
+          path: build/docs
+
+      - name: Download artifact (coverage)
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact-coverage
+          path: build/cov
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build
+          destination_dir: ./
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+  cleanup:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: deploy
+    steps:
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          failOnError: false
+          name: |
+            artifact-*


### PR DESCRIPTION
* build workflow for build check only
* doc and reports generation on main branch only

The build workflow is used to check the proper build and tests on
commits in the main branch but also on any PR. The documentation
and quality reports should only be generated on main branch, as
such this splits them off in a separate workflow.
